### PR TITLE
Add AOT Compatibility

### DIFF
--- a/src/UFX.Relay/UFX.Relay.csproj
+++ b/src/UFX.Relay/UFX.Relay.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
 	    <IsAotCompatible>true</IsAotCompatible>
+	    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
         <IsPackable>true</IsPackable>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/UFX.Relay/UFX.Relay.csproj
+++ b/src/UFX.Relay/UFX.Relay.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
-	    <IsAotCompatible>true</IsAotCompatible>
-	    <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
+        <IsAotCompatible>true</IsAotCompatible>
+        <EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>
         <IsPackable>true</IsPackable>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>

--- a/src/UFX.Relay/UFX.Relay.csproj
+++ b/src/UFX.Relay/UFX.Relay.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Library</OutputType>
+	    <IsAotCompatible>true</IsAotCompatible>
         <IsPackable>true</IsPackable>
         <PackageReadmeFile>README.md</PackageReadmeFile>
     </PropertyGroup>


### PR DESCRIPTION
We've been using UFX.Relay and have a technical spike where we've created a tunnel which runs on a Linux distro. We created a second technical spike to see if we could use AOT to create a native compilation and our solution generated some warnings pointing back to UFX.Relay. We realised that the the same fixes we applied to our solution also solve the issue for UFX.Relay.

Adding `<IsAotCompatible>true</IsAotCompatible>` (see [docs](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/?tabs=windows%2Cnet8#aot-compatibility-analyzers)) to `UFX.Relay.csproj` causes the following errors to be generated:

```
TunnelBuilderExtensions.cs(33,16,38,11): error IL3050: Using member 'Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapGet(IEndpointRouteBuilder, String, Delegate)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. This API may perform reflection on the supplied delegate and its parameters. These types may require generated code and aren't compatible with native AOT applications.

TunnelBuilderExtensions.cs(33,16,38,11): error IL2026: Using member 'Microsoft.AspNetCore.Builder.EndpointRouteBuilderExtensions.MapGet(IEndpointRouteBuilder, String, Delegate)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. This API may perform reflection on the supplied delegate and its parameters. These types may be trimmed if not directly referenced.
```

These errors are resolved by adding: `<EnableRequestDelegateGenerator>true</EnableRequestDelegateGenerator>` to `UFX.Relay.csproj`


