### PR TITLE
Add socket conn retry on TaskCanceledException

### DIFF
--- a/src/UFX.Relay/Tunnel/Listener/TunnelConnectionListener.cs
+++ b/src/UFX.Relay/Tunnel/Listener/TunnelConnectionListener.cs
@@ -35,7 +35,7 @@ public class TunnelConnectionListener(TunnelEndpoint tunnelEndpoint, ITunnelIdPr
         unbindTokenSource = new CancellationTokenSource();
         endpoint = tunnelEndpoint;
         endpoint.TunnelId = await tunnelIdProvider.GetTunnelIdAsync() ?? throw new KeyNotFoundException("TunnelId not found");
-        var cts = new CancellationTokenSource(5000);
+        var cts = new CancellationTokenSource(10000);
         tunnelEndpoint.Tunnel = await tunnelManager.GetOrCreateTunnelAsync(endpoint.TunnelId, cts.Token);
     }
 


### PR DESCRIPTION
This PR is more for discussion. Bear in mind that I have very little understanding of websockets.

In my scenario, what I observed is that the first connection attempt always fails with `TaskCanceledException`. Then even if I sleep as little as 10ms, it works.

I also had to increase the Cancellation time from 5 to 10 seconds, because the first failing attempt takes a little while. Note that I'm connecting to a container that just launched and needs to settle.

Good news is that the whole scenario appears to work quite well once I get passed that!