### PR TITLE
Tunnel.GetChannelAsync() fails fast if socket connection fails (#16)

### DIFF
--- a/src/UFX.Relay/Tunnel/UnderlyingStreamClosedException.cs
+++ b/src/UFX.Relay/Tunnel/UnderlyingStreamClosedException.cs
@@ -1,0 +1,5 @@
+namespace UFX.Relay.Tunnel;
+
+public class UnderlyingStreamClosedException() : OperationCanceledException
+{
+}


### PR DESCRIPTION
Previously `GetChannelAsync()` would wait forever if the underlying stream had died/closed. Now it throws an `UnderlyingStreamClosedException` (subclass of `OperationCanceledException`).

The `TunnelConnectionListener` recognises this and retries the connection.